### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.chaitanyapramod.findbugs-android'
 
 findbugs {
-  toolsVersion '3.0.1'
+  toolVersion '3.0.1'
   ignoreFailures true
   effort 'max'
   reportLevel 'high'


### PR DESCRIPTION
I found a typo in README.md when setting up your plugin. 
FindBugsExtension doesn't have a `toolsVersion` method but has a `toolVersion` method.

ref: https://github.com/gradle/gradle/blob/6dcb7ac681f814f3bf6f10ed3550e29285933313/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeQualityExtension.java#L43

Thanks.